### PR TITLE
fix: exclude README_test_deploy.md from Sphinx build

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -35,6 +35,7 @@ exclude_patterns = [
     ".nox/*",
     "README.md",
     "README_original_template.md",
+    "README_test_deploy.md",  # exclude test-deploy specific README
     "**/.ipynb_checkpoints/*",
     "jupyter_execute",
     "conf.py",


### PR DESCRIPTION
This PR fixes the GitHub Actions deployment failure by excluding README_test_deploy.md from the Sphinx build process. The file was causing a 'document isn't included in any toctree' warning which became a fatal error due to the -nW flag.