### PR TITLE
Add issue GitHub issue forms for users

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Report an Issue 
-description: Report something that is not working as expected in the Data Catalog. | Please fill out the template below with as much information as possible to help us understand and fix the issue.
+description: Report something that is not working as expected in the Data Catalog. Please fill out the template below with as much information as possible to help us understand and fix the issue.
 title: "[Issue]: "
 labels: ["bug"]
 projects: ["biosustain/12"]
@@ -13,7 +13,7 @@ body:
       placeholder: e.g. When I click on the search button, nothing happens.
     validations:
       required: true
-  - type: texterea
+  - type: textarea
     id: steps-to-reproduce
     attributes:
       label: Steps to reproduce

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,6 +17,17 @@ body:
       placeholder: e.g. When I click on the search button, nothing happens.
     validations:
       required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: How severe is the issue?
+      options:
+        - 🔴 Blocking - I cannot use the Data Catalog at all
+        - 🟠 High - An important feature is not working
+        - 🟡 Medium - Feature is partially working
+        - 🟢 Low - Minor issue that does not affect my work
+    validations:
+      required: true
   - type: textarea
     id: steps-to-reproduce
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Report an Issue 
+description: Report something that is not working as expected in the Data Catalog. | Please fill out the template below with as much information as possible to help us understand and fix the issue.
+title: "[Issue]: "
+labels: ["bug"]
+projects: ["biosustain/12"]
+type: bug
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What is the issue?
+      description: Please describe the issue you are facing in detail.
+      placeholder: e.g. When I click on the search button, nothing happens.
+    validations:
+      required: true
+  - type: texterea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Please provide a step-by-step description of how to reproduce the issue.
+      placeholder: |
+        1. Go to the ...
+        2. Click on ...
+        3. See the error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: e.g. The search results should have been filtered by "Created by"
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:     
+      label: Screenshots or Error Messages
+      description: If applicable, please provide any screenshots or error messages that can help us understand the issue better.
+      placeholder: Drag and drop your screenshots here or copy and paste any error messages.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: Report an Issue 
+name: 🔧Report an Issue 
 description: Something not working as expected in the Data Catalog?
 title: "[Issue]: "
 labels: ["bug"]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,10 +1,14 @@
 name: Report an Issue 
-description: Report something that is not working as expected in the Data Catalog. Please fill out the template below with as much information as possible to help us understand and fix the issue.
+description: Something not working as expected in the Data Catalog?
 title: "[Issue]: "
 labels: ["bug"]
 projects: ["biosustain/12"]
 type: bug
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the form below with as much detail as you can about the issue you are experiencing in the Data Catalog. This will help us understand the problem and resolve it faster. Thank you for taking the time to report this issue!
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature Request
+description: Have an idea for a new feature or improvement in the Data Catalog? 
+title: "[Feature Request]: "
+labels: ["enhancement"]
+projects: ["biosustain/12"]
+type: feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to suggest a new feature! Please fill out the form below with as much detail as you can to help us understand your request.
+  - type: textarea
+    id: description
+    attributes:
+      label: What feature would you like to see?
+      description: Please describe the feature you would like to see in the Data Catalog.
+      placeholder: e.g. A filter to search datasets by creation date.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this feature solve?
+      description: Help us understand the motivation behind your request.
+      placeholder: e.g. I often need to find datasets created in a specific time period but currently I have to scroll through all results.
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots or examples that might help us understand your request better.
+      placeholder: Drag and drop screenshots here or add any additional information.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,4 @@
-name: Feature Request
+name: ✨Feature Request
 description: Have an idea for a new feature or improvement in the Data Catalog? 
 title: "[Feature Request]: "
 labels: ["enhancement"]

--- a/.github/ISSUE_TEMPLATE/help.yml
+++ b/.github/ISSUE_TEMPLATE/help.yml
@@ -1,0 +1,27 @@
+name: I Need Help
+description: Not sure how to do something in the Data Catalog? We are here to help!
+title: "[Help]: "
+labels: ["question"]
+projects: ["biosustain/12"]
+type: task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Not sure how to do something in the Data Catalog? We are here to help! Please fill out the form below with as much detail as you can so we can point you in the right direction.
+  - type: textarea
+    id: question
+    attributes:
+      label: What do you need help with?
+      description: Please describe what you are trying to do and where are you getting stuck.
+      placeholder: e.g. I am trying to find all datasets related to a specific project but I am not sure how to search for them.
+    validations:
+      required: true
+  - type: textarea
+    id: additional  
+    attributes:
+      label: Additional Context
+      description: Add any screenshots or additional information that might help us understand your question better.
+      placeholder: Drag and drop screenshots here or add any additional information.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/help.yml
+++ b/.github/ISSUE_TEMPLATE/help.yml
@@ -1,4 +1,4 @@
-name: I Need Help
+name: 💬I Need Help
 description: Not sure how to do something in the Data Catalog? We are here to help!
 title: "[Help]: "
 labels: ["question"]


### PR DESCRIPTION
## What does this PR do?
Adds three GitHub issue forms to help users report issues, request features and ask questions with Data Catalog. This replaces the blank issue form and guides users to provide the information we need.

## Forms added
-  **Report an Issue** - for reporting something that is not working as expected
-  **Feature Request** - for suggesting new features or improvements
-  **I Need Help** - for general questions and guidance

New issues submitted through these forms will be automatically added to the [RDM project board](https://github.com/orgs/biosustain/projects/12)